### PR TITLE
Stop listening on onTouchCancel.

### DIFF
--- a/src/TapEventPlugin.js
+++ b/src/TapEventPlugin.js
@@ -83,7 +83,6 @@ var dependencies = [
 
 if (EventPluginUtils.useTouchEvents) {
   dependencies.push(
-    topLevelTypes.topTouchCancel,
     topLevelTypes.topTouchEnd,
     topLevelTypes.topTouchStart,
     topLevelTypes.topTouchMove


### PR DESCRIPTION
Hi!

Im using this event for a little app, and noticed that on the default android browser (at least the ones of <= 4.4.4) generates falses onTouchCancel events when scrolling.

When you touchStart and move the finger, onTouchCancel is getting triggered (with the finger still pressed).
This plugin treat it as a isEndish() so its emitting the onTouchTap event, making the app not very useful.

Probably not everyone loves the default chrome browser, but its the default, and is what been used when you phongap/cordova-ize you app.

Thanks!!



