### PR TITLE
This plugin crashes Chrome's remote inspector

### DIFF
--- a/src/injectTapEventPlugin.js
+++ b/src/injectTapEventPlugin.js
@@ -1,9 +1,3 @@
 module.exports = function injectTapEventPlugin () {
-  var React = require("react");
-  React.initializeTouchEvents(true);
-
-  require('react/lib/EventPluginHub').injection.injectEventPluginsByName({
-    "ResponderEventPlugin": require('./ResponderEventPlugin.js'),
-    "TapEventPlugin":       require('./TapEventPlugin.js')
-  });
+  
 };


### PR DESCRIPTION
Since you don't have issues enabled I'm creating a worthless PR.

If you have an Android device you can use chrome://inspect/ to get the remote inspector. if `react-tap-event-plugin` in included in your app it'll crash the inspector. I'm hoping someone familiar with the codebase can take a look and see what's going on. I can't really debug it as it's crashing my only available debugger.