### PR TITLE
Generate now function ahead of time

### DIFF
--- a/src/TapEventPlugin.js
+++ b/src/TapEventPlugin.js
@@ -99,14 +99,16 @@ var eventTypes = {
   }
 };
 
-var now = function() {
+var now = (function() {
   if (Date.now) {
-    return Date.now();
+    return Date.now;
   } else {
     // IE8 support: http://stackoverflow.com/questions/9430357/please-explain-why-and-how-new-date-works-as-workaround-for-date-now-in
-    return +new Date;
+    return function () {
+      return +new Date;
+    }
   }
-}
+})();
 
 var TapEventPlugin = {
 


### PR DESCRIPTION
I'm not sure if this code is hit often enough to
make this micro-optimisation worth it, but we
can generate the now function at load-time
rather than checking how to get it every time
we call it.