### PR TITLE
Allow user-specified click rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,34 @@ var Main = React.createClass({
 ReactDOM.render(<Main />, document.getElementById("container"));
 ```
 
+### Ignoring ghost clicks
+
+When a tap happens, the browser sends a `touchstart` and `touchend`, and then
+300ms later, a `click` event. This plugin ignores the click event if it has
+been immediately preceeded by a touch event (within 750ms of the last touch
+event).
+
+Occasionally, there may be times when the 750ms threshold is exceeded due to
+slow rendering or garbage collection, and this causes the dreaded ghost click.
+
+The 750ms threshold is pretty good, but sometimes you might want to override
+that behaviour. You can do this by supplying your own `shouldRejectClick`
+function when you inject the plugin.
+
+The following example will simply reject all click events, which you might
+want to do if you are always using `onTouchTap` and only building for touch
+devices:
+
+```js
+var React = require('react'),
+injectTapEventPlugin = require("react-tap-event-plugin");
+injectTapEventPlugin({
+  shouldRejectClick: function (lastTouchEventTimestamp, clickEventTimestamp) {
+    return true;
+  }
+});
+```
+
 ## Build standalone version
 
 Use the demo project and it's README instructions to build a version of React with the tap event plugin included.

--- a/src/defaultClickRejectionStrategy.js
+++ b/src/defaultClickRejectionStrategy.js
@@ -1,5 +1,5 @@
 module.exports = function(lastTouchEvent, clickTimestamp) {
   if (lastTouchEvent && (clickTimestamp - lastTouchEvent) < 750) {
-    return null;
+    return true;
   }
 };

--- a/src/defaultClickRejectionStrategy.js
+++ b/src/defaultClickRejectionStrategy.js
@@ -1,0 +1,5 @@
+module.exports = function(lastTouchEvent, clickTimestamp) {
+  if (lastTouchEvent && (clickTimestamp - lastTouchEvent) < 750) {
+    return null;
+  }
+};

--- a/src/injectTapEventPlugin.js
+++ b/src/injectTapEventPlugin.js
@@ -1,5 +1,10 @@
-module.exports = function injectTapEventPlugin () {
+var defaultClickRejectionStrategy = require("./defaultClickRejectionStrategy");
+
+module.exports = function injectTapEventPlugin (strategyOverrides) {
+  strategyOverrides = strategyOverrides || {}
+  var shouldRejectClick = strategyOverrides.shouldRejectClick || defaultClickRejectionStrategy;
+
   require('react/lib/EventPluginHub').injection.injectEventPluginsByName({
-    "TapEventPlugin":       require('./TapEventPlugin.js')
+    "TapEventPlugin":       require('./TapEventPlugin.js')(shouldRejectClick)
   });
 };


### PR DESCRIPTION
There are occasions where you might want to reject clicks using a
different strategy than just based on time-between-events. This
allows the consumer to supply their own way of deciding whether or
not to trigger the click event.