### PR TITLE
fix(npm): changing react dependency since v0.14 is not official yet.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "peerDependencies": {
     "fbjs": "^0.2.1",
-    "react": "^0.14.0-0"
+    "react": "^0.13.3"
   },
   "bugs": "https://github.com/zilverline/react-tap-event-plugin/issues",
   "licenses": [


### PR DESCRIPTION
Simple fix to make lib available for `React 0.13.3` which is actually official version.