### PR TITLE
[npm] move fbjs from peerDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "react-tap-event-plugin"
   ],
   "peerDependencies": {
-    "fbjs": "^0.2.1",
     "react": "^0.14.0-0"
+  },
+  "dependencies": {
+    "fbjs": "^0.2.1"
   },
   "bugs": "https://github.com/zilverline/react-tap-event-plugin/issues",
   "licenses": [


### PR DESCRIPTION
According to [fbjs](https://github.com/facebook/fbjs)
> If you are consuming the code here and you are not also a Facebook project, be prepared for a bad time. **APIs may appear or disappear**

So I think that this dependency shouldn't be a peerDependency.