### PR TITLE
make tapMoveThreshold configurable

### DIFF
--- a/src/TapEventPlugin.js
+++ b/src/TapEventPlugin.js
@@ -42,11 +42,6 @@ var isTouch = function(topLevelType) {
   return touchTypes.indexOf(topLevelType) >= 0;
 }
 
-/**
- * Number of pixels that are tolerated in between a `touchStart` and `touchEnd`
- * in order to still be considered a 'tap' event.
- */
-var tapMoveThreshold = 10;
 var ignoreMouseThreshold = 750;
 var startCoords = {x: null, y: null};
 var lastTouchEvent = null;
@@ -109,9 +104,13 @@ var now = (function() {
   }
 })();
 
-function createTapEventPlugin(shouldRejectClick) {
+function createTapEventPlugin(shouldRejectClick, tapMoveThreshold) {
   return {
 
+    /**
+     * Number of pixels that are tolerated in between a `touchStart` and `touchEnd`
+     * in order to still be considered a 'tap' event.
+     */
     tapMoveThreshold: tapMoveThreshold,
 
     ignoreMouseThreshold: ignoreMouseThreshold,

--- a/src/injectTapEventPlugin.js
+++ b/src/injectTapEventPlugin.js
@@ -3,7 +3,7 @@ var defaultClickRejectionStrategy = require('./defaultClickRejectionStrategy');
 
 var alreadyInjected = false;
 
-module.exports = function injectTapEventPlugin (strategyOverrides) {
+module.exports = function injectTapEventPlugin (strategyOverrides, tapMoveThreshold) {
   strategyOverrides = strategyOverrides || {}
   var shouldRejectClick = strategyOverrides.shouldRejectClick || defaultClickRejectionStrategy;
 
@@ -19,8 +19,9 @@ should be injected by the application.'
   }
 
   alreadyInjected = true;
+  tapMoveThreshold = tapMoveThreshold || 10;
 
   require('react/lib/EventPluginHub').injection.injectEventPluginsByName({
-    'TapEventPlugin':       require('./TapEventPlugin.js')(shouldRejectClick)
+    "TapEventPlugin":       require('./TapEventPlugin.js')(shouldRejectClick, tapMoveThreshold)
   });
 };


### PR DESCRIPTION
I've found that the tapMoveThreshold is too low for some devices / applications, this changes allows it to be configurable.