### PR TITLE
Update to be compatible with React 15

### DIFF
--- a/src/TapEventPlugin.js
+++ b/src/TapEventPlugin.js
@@ -120,18 +120,17 @@ function createTapEventPlugin(shouldRejectClick) {
 
     /**
      * @param {string} topLevelType Record from `EventConstants`.
-     * @param {DOMEventTarget} topLevelTarget The listening component root node.
-     * @param {string} topLevelTargetID ID of `topLevelTarget`.
+     * @param {DOMEventTarget} targetInst The listening component root node.
      * @param {object} nativeEvent Native browser event.
      * @return {*} An accumulation of synthetic events.
      * @see {EventPluginHub.extractEvents}
      */
     extractEvents: function(
-        topLevelType,
-        topLevelTarget,
-        topLevelTargetID,
-        nativeEvent,
-        nativeEventTarget) {
+      topLevelType,
+      targetInst,
+      nativeEvent,
+      nativeEventTarget
+    ) {
 
       if (isTouch(topLevelType)) {
         lastTouchEvent = now();
@@ -149,7 +148,7 @@ function createTapEventPlugin(shouldRejectClick) {
       if (isEndish(topLevelType) && distance < tapMoveThreshold) {
         event = SyntheticUIEvent.getPooled(
           eventTypes.touchTap,
-          topLevelTargetID,
+          targetInst,
           nativeEvent,
           nativeEventTarget
         );


### PR DESCRIPTION
This updates the code to be compatible with React 15.

Fixes https://github.com/zilverline/react-tap-event-plugin/issues/64, https://github.com/facebook/react/issues/6221.

You’ll also need to update `react` in `package.json` as well as `react` and `react-dom` in `demo/package.json` to `^15.0.0-0`, I didn’t include this in the PR.

Cheers!