### PR TITLE
Offer a `isInjected` function to allow user check if plugin is injected

### DIFF
--- a/src/injectTapEventPlugin.js
+++ b/src/injectTapEventPlugin.js
@@ -3,7 +3,7 @@ var defaultClickRejectionStrategy = require('./defaultClickRejectionStrategy');
 
 var alreadyInjected = false;
 
-module.exports = function injectTapEventPlugin (strategyOverrides) {
+exports = module.exports = function injectTapEventPlugin (strategyOverrides) {
   strategyOverrides = strategyOverrides || {}
   var shouldRejectClick = strategyOverrides.shouldRejectClick || defaultClickRejectionStrategy;
 
@@ -23,4 +23,8 @@ should be injected by the application.'
   require('react-dom/lib/EventPluginHub').injection.injectEventPluginsByName({
     'TapEventPlugin':       require('./TapEventPlugin.js')(shouldRejectClick)
   });
+};
+
+exports.isInjected = function isInjected () {
+  return alreadyInjected;
 };


### PR DESCRIPTION
When develop react app with `webpack-hot-middleware` to enable hot reload, `react-tap-event-plugin` will always print warning message:

```bash
Invariant Violation: injectTapEventPlugin(): Can only be called once per application lifecycle.

It is recommended to call injectTapEventPlugin() just before you call ReactDOM.render(). If you are using an external library which calls injectTapEventPlugin() itself, please contact the maintainer as it shouldn't be called in library code and should be injected by the application.
    at invariant (/REPO/node_modules/fbjs/lib/invariant.js:44:15)
    at injectTapEventPlugin (/REPO/node_modules/react-tap-event-plugin/src/injectTapEventPlugin.js:11:5)
    at Object../src/components/Layout/index.js (/REPO/src/components/Layout/index.js:14:1)
    at __webpack_require__ (/REPO/webpack/bootstrap aeb843e7799316fcb8cb:635:1)
    at fn (/REPO/webpack/bootstrap aeb843e7799316fcb8cb:47:1)
    at Object../src/routes/home/index.js (/REPO/build/chunks/home.js:318:77)
    at __webpack_require__ (/REPO/webpack/bootstrap aeb843e7799316fcb8cb:635:1)
    at fn (/REPO/webpack/bootstrap aeb843e7799316fcb8cb:47:1)
    at <anonymous>
```

It's annoying and will prevent hot reload working correctly.

So, it's great to offser something like:

```js
if (!injectTapEventPlugin.isInjected()) {
  injectTapEventPlugin()
}
```